### PR TITLE
refine chromeloader and chromefinder for clearer design

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,20 +3,22 @@ package config
 import "github.com/ebisuG/search-all-user-bookmark/internal/search"
 
 type Config struct {
-	SearchPath []string
+	SearchPath SearchPath
 	CliSetting CliSetting
 }
+
+type SearchPath []string
 
 type CliSetting struct {
 	UserName string `json:"username"`
 }
 
 type Loader interface {
-	Load(path string) (Config, error)
+	Load(path string) (CliSetting, error)
 }
 
 type Finder interface {
-	Find(conf Config) ([]string, error)
+	Find(cli CliSetting) (SearchPath, error)
 }
 
 type Parser interface {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,5 @@
 package config
 
-import "github.com/ebisuG/search-all-user-bookmark/internal/search"
-
 type Config struct {
 	SearchPath SearchPath
 	CliSetting CliSetting
@@ -19,8 +17,4 @@ type Loader interface {
 
 type Finder interface {
 	Find(cli CliSetting) (SearchPath, error)
-}
-
-type Parser interface {
-	Parse(path string) ([]search.Bookmark, error)
 }

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ebisuG/search-all-user-bookmark/internal/config"
 	"github.com/ebisuG/search-all-user-bookmark/internal/search"
-	"github.com/mattn/go-runewidth"
 	"golang.org/x/text/cases"
 )
 
@@ -135,33 +134,4 @@ func (c CoreSearcher) Search(bookmarks search.Bookmarks, keyword string) (search
 		}
 	}
 	return result, nil
-}
-
-func firstChars(fixedLength int, s string) string {
-	result := ""
-	currentWidth := 0
-	ellipsis := "..."
-
-	for _, r := range s {
-		w := runewidth.RuneWidth(r)
-		if currentWidth+w >= fixedLength-len(ellipsis) {
-			result += ellipsis
-			currentWidth += len(ellipsis)
-			break
-		}
-		result += string(r)
-		currentWidth += w
-	}
-
-	if currentWidth <= fixedLength {
-		result += runewidth.FillRight("", fixedLength-currentWidth)
-	}
-
-	return result
-}
-
-func CheckError(e error) {
-	if e != nil {
-		panic(e)
-	}
 }

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -17,7 +17,6 @@ import (
 // This struct is for CLI settings
 type ChromeLoader struct{}
 type ChromeFinder struct{}
-type ChromeParser struct{}
 
 func (c ChromeLoader) Load(path string) (config.CliSetting, error) {
 	data, err := os.ReadFile(path)
@@ -86,6 +85,8 @@ type ChromeChild struct {
 type ChromeMetaInfo struct {
 	PowerBookmarkMeta string `json:"power_bookmark_meta"`
 }
+
+type ChromeParser struct{}
 
 func (c ChromeParser) Parse(path string) ([]search.Bookmark, error) {
 	var bookmarks []search.Bookmark

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -19,28 +19,28 @@ type ChromeLoader struct{}
 type ChromeFinder struct{}
 type ChromeParser struct{}
 
-func (c ChromeLoader) Load(path string) (config.Config, error) {
+func (c ChromeLoader) Load(path string) (config.CliSetting, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Println(err)
-		return config.Config{}, errors.New("failed to load config")
+		return config.CliSetting{}, errors.New("failed to load config")
 	}
 
-	var conf config.Config
-	if err := json.Unmarshal(data, &conf.CliSetting); err != nil {
+	var cliSetting config.CliSetting
+	if err := json.Unmarshal(data, &cliSetting); err != nil {
 		fmt.Println(err)
-		return config.Config{}, errors.New("failed to parse json")
+		return config.CliSetting{}, errors.New("failed to parse json")
 	}
-	return conf, nil
+	return cliSetting, nil
 }
 
-func (c ChromeFinder) Find(conf config.Config) ([]string, error) {
-	base := "C:\\Users\\" + conf.CliSetting.UserName + "\\AppData\\Local\\Google\\Chrome\\User Data"
+func (c ChromeFinder) Find(cliSetting config.CliSetting) (config.SearchPath, error) {
+	base := "C:\\Users\\" + cliSetting.UserName + "\\AppData\\Local\\Google\\Chrome\\User Data"
 	files, err := os.ReadDir(base)
 	if err != nil {
 		panic(err)
 	}
-	var bookmarksFilePath []string
+	var bookmarksFilePath config.SearchPath
 	bookmarksFilePath = append(bookmarksFilePath, base+"\\"+"Default"+"\\Bookmarks")
 	r, _ := regexp.Compile("^Profile [0-9]*")
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -4,6 +4,10 @@ type Searcher interface {
 	Search(bookmarks Bookmarks, keyword string) (Bookmarks, error)
 }
 
+type Parser interface {
+	Parse(path string) ([]Bookmark, error)
+}
+
 type Bookmarks []Bookmark
 
 type Bookmark struct {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,13 +1,5 @@
 package search
 
-type Searcher interface {
-	Search(bookmarks Bookmarks, keyword string) (Bookmarks, error)
-}
-
-type Parser interface {
-	Parse(path string) ([]Bookmark, error)
-}
-
 type Bookmarks []Bookmark
 
 type Bookmark struct {
@@ -26,4 +18,12 @@ type BookmarkUrl struct {
 type Record struct {
 	Raw  string
 	Norm string
+}
+
+type Searcher interface {
+	Search(bookmarks Bookmarks, keyword string) (Bookmarks, error)
+}
+
+type Parser interface {
+	Parse(path string) ([]Bookmark, error)
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ebisuG/search-all-user-bookmark/internal/config"
 	"github.com/ebisuG/search-all-user-bookmark/internal/infra"
 	"github.com/ebisuG/search-all-user-bookmark/internal/search"
+	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -152,9 +153,33 @@ func (m model) View() string {
 
 func (r result) FormatDisplay() {
 	nameColor := lipgloss.Color("#F77F0F")
+	lineLength := 100
 
 	for _, v := range r {
-		hypelink := termenv.Hyperlink(v.bookmarkUrl.record.raw, v.bookmarkTitle.record.raw)
+		hypelink := termenv.Hyperlink(v.bookmarkUrl.record.raw, firstChars(lineLength, v.bookmarkTitle.record.raw))
 		fmt.Println(" ", lipgloss.NewStyle().Foreground(nameColor).Bold(false).Render(hypelink))
 	}
+}
+
+func firstChars(fixedLength int, s string) string {
+	result := ""
+	currentWidth := 0
+	ellipsis := "..."
+
+	for _, r := range s {
+		w := runewidth.RuneWidth(r)
+		if currentWidth+w >= fixedLength-len(ellipsis) {
+			result += ellipsis
+			currentWidth += len(ellipsis)
+			break
+		}
+		result += string(r)
+		currentWidth += w
+	}
+
+	if currentWidth <= fixedLength {
+		result += runewidth.FillRight("", fixedLength-currentWidth)
+	}
+
+	return result
 }

--- a/main.go
+++ b/main.go
@@ -72,17 +72,19 @@ func InitialModel() model {
 	fmt.Println(lipgloss.NewStyle().Foreground(lipgloss.Color("#a871f0")).Bold(true).SetString("Press Ctrl to jummp to bookmark"))
 	fmt.Println("Reading all bookmark files...")
 
+	var config config.Config
 	chromeLoader := NewChromeLoader()
 	chromeFinder := NewChromeFinder()
-	chromeConf, err := chromeLoader.Load("./settings.json")
+	clisetting, err := chromeLoader.Load("./settings.json")
 	if err != nil {
 		fmt.Println(err)
 		return model{}
 	}
+	config.CliSetting = clisetting
 	fmt.Println("Finish loading settings.json")
-	chromeConf.SearchPath, err = chromeFinder.Find(chromeConf)
+	config.SearchPath, err = chromeFinder.Find(config.CliSetting)
 
-	return model{searchString: ti, config: chromeConf}
+	return model{searchString: ti, config: config}
 }
 
 func (m model) Init() tea.Cmd {

--- a/main.go
+++ b/main.go
@@ -111,7 +111,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			var bookmarks search.Bookmarks
 			chromeParser := NewChromeParser()
-			fmt.Println(m.config.SearchPath)
 			for _, v := range m.config.SearchPath {
 				bookmark, err := chromeParser.Parse(v)
 				if err != nil {


### PR DESCRIPTION
## Problem
The relationship and execution order between `Loader` and `Finder` were unclear in `config.go`.  
The dependency between them was implicit and not expressed at the **type level**.

## Goal
Make the dependency and call order between `Loader` and `Finder` explicit through clearer type boundaries.

## Implementation
- Refined the type definitions of `Loader` and `Finder` so that `Loader` returns `CliSetting`, and `Finder` consumes it to produce `SearchPath`.
- Moved the `Parser` interface from `config` to `search`, since it produces `Bookmark`, which is a core domain type owned by `search`.
- Truncate displayed line to the first 100 characters again at https://github.com/ebisuG/search-all-user-bookmark/pull/44/changes/04ecf12ba500072e5c0ba550c226c613cdf76d9f .

## Result
- The dependency flow between `Loader` and `Finder` is now explicit.
- The execution order is enforced by types rather than implicit convention.
- The `search` package now owns the abstraction required to produce its domain model (`Bookmark`).