### PR TITLE
46 refine error handling

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,0 +1,65 @@
+## Error handling
+### 1. Simple Failure
+In this case, caller doesn't need to switch following logic. Just check if error occured.
+```go
+func ReturnSimple() (string, error){
+    return "", fmt.Errorf("This is simple error just value")
+}
+
+simple, err := ReturnSimple()
+if err!=nil{
+    //fmt.Println(err) or
+    //os.Exit()
+}
+```
+
+### 2. Simple Custom Error
+Define error value to check by errors.Is(). Export error struct as official or unify error in a pacakge.
+```go
+var ErrNotFound = errors.New("not found")
+func readFile(path string)(File, error){
+    //There is no file to read
+    return File{}, ErrNotFound
+}
+
+func EditFile(path string){
+    file, err := readFile("./text.txt")
+    if errors.Is(err, ErrNotFound){
+        //do something, like create a new file
+    }
+}
+```
+
+### 3. Complex Custome Error
+Analyze error detail and handle it with field of error struct.
+```go
+type ConnectionError struct {
+    WaitTime int
+}
+
+func (e *ConnectionError) Error() string {
+    return fmt.Sprintf("connection failed, wait %d", e.WaitTime)
+}
+
+func GetOriginalResponse()(Response, error){
+    //something fails
+    return Response{}, fmt.Errorf("%w", &ConnectionError{WaitTime:100})
+}
+
+res, err := GetOriginalResponse()
+
+var ce *ConnectionError
+if errors.As(err, &ce) {
+    if ce.WaitTime <= 50{
+        //do something
+    }else if ce.WaitTime <= 100 {
+        //do something
+    }else{
+        //...
+    }
+}
+
+```
+
+### Reference
+https://leapcell.io/blog/the-subtle-art-of-error-creation-understanding-errors-new-and-fmt-errorf-in-go#:~:text=for%20future%20refactors.-,General%20Guideline%3A,-Lean%20towards%20fmt

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,3 +18,21 @@ type Loader interface {
 type Finder interface {
 	Find(cli CliSetting) (SearchPath, error)
 }
+
+type NotFoundError struct {
+	FilePath string
+}
+
+func (e *NotFoundError) Error() string { return "No such file : " + e.FilePath }
+
+type InvalidFormatError struct{}
+
+func (e *InvalidFormatError) Error() string { return "Invalid format" }
+
+type NotFoundBookmarkFileError struct {
+	Path string
+}
+
+func (e *NotFoundBookmarkFileError) Error() string {
+	return "not found : " + e.Path
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "errors"
+
 type Config struct {
 	SearchPath SearchPath
 	CliSetting CliSetting
@@ -25,9 +27,7 @@ type NotFoundError struct {
 
 func (e *NotFoundError) Error() string { return "No such file : " + e.FilePath }
 
-type InvalidFormatError struct{}
-
-func (e *InvalidFormatError) Error() string { return "Invalid format" }
+var ErrInvalidFormat = errors.New("invalid format")
 
 type NotFoundBookmarkFileError struct {
 	Path string

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -20,14 +20,13 @@ type ChromeFinder struct{}
 func (c ChromeLoader) Load(path string) (config.CliSetting, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		fmt.Println(err)
-		return config.CliSetting{}, errors.New("failed to load config")
+		//TODO : if debug mode on, display detailed data
+		return config.CliSetting{}, fmt.Errorf("%w", config.NotFoundError{FilePath: path})
 	}
 
 	var cliSetting config.CliSetting
 	if err := json.Unmarshal(data, &cliSetting); err != nil {
-		fmt.Println(err)
-		return config.CliSetting{}, errors.New("failed to parse json")
+		return config.CliSetting{}, fmt.Errorf("%w", config.InvalidFormatError{})
 	}
 	return cliSetting, nil
 }
@@ -36,7 +35,7 @@ func (c ChromeFinder) Find(cliSetting config.CliSetting) (config.SearchPath, err
 	base := "C:\\Users\\" + cliSetting.UserName + "\\AppData\\Local\\Google\\Chrome\\User Data"
 	files, err := os.ReadDir(base)
 	if err != nil {
-		panic(err)
+		return config.SearchPath{}, errors.New("no such directory : " + base)
 	}
 	var bookmarksFilePath config.SearchPath
 	bookmarksFilePath = append(bookmarksFilePath, base+"\\"+"Default"+"\\Bookmarks")
@@ -48,7 +47,9 @@ func (c ChromeFinder) Find(cliSetting config.CliSetting) (config.SearchPath, err
 			bookmarksFilePath = append(bookmarksFilePath, base+"\\"+v.Name()+"\\Bookmarks")
 		}
 	}
-
+	if len(bookmarksFilePath) == 0 {
+		return config.SearchPath{}, fmt.Errorf("%w", config.NotFoundBookmarkFileError{Path: base})
+	}
 	return bookmarksFilePath, nil
 }
 

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -26,7 +26,7 @@ func (c ChromeLoader) Load(path string) (config.CliSetting, error) {
 
 	var cliSetting config.CliSetting
 	if err := json.Unmarshal(data, &cliSetting); err != nil {
-		return config.CliSetting{}, fmt.Errorf("%w", config.InvalidFormatError{})
+		return config.CliSetting{}, fmt.Errorf("%w", config.ErrInvalidFormat)
 	}
 	return cliSetting, nil
 }

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -95,7 +95,9 @@ func (c ChromeParser) Parse(path string) ([]search.Bookmark, error) {
 		return bookmarks, errors.New("no file")
 	}
 	var chromeJson ChromeParentJson
-	json.Unmarshal(data, &chromeJson)
+	if err := json.Unmarshal(data, &chromeJson); err != nil {
+		return bookmarks, errors.New("Invalid format")
+	}
 	for i := 0; i < len(chromeJson.Roots.BookmarkBar.Children); i++ {
 		bookmark := chromeJson.Roots.BookmarkBar.Children[i]
 		bookmarks = append(bookmarks, GetChildren(bookmark)...)

--- a/main.go
+++ b/main.go
@@ -79,10 +79,9 @@ func InitialModel() model {
 	clisetting, err := chromeLoader.Load("./settings.json")
 	if err != nil {
 		var nf *config.NotFoundError
-		var ife *config.InvalidFormatError
 		if errors.As(err, &nf) {
 			fmt.Println("no setting.json file")
-		} else if errors.As(err, &ife) {
+		} else if errors.Is(err, config.ErrInvalidFormat) {
 			fmt.Println("invalid format")
 		} else {
 			fmt.Println(err)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -73,19 +74,37 @@ func InitialModel() model {
 	fmt.Println(lipgloss.NewStyle().Foreground(lipgloss.Color("#a871f0")).Bold(true).SetString("Press Ctrl to jummp to bookmark"))
 	fmt.Println("Reading all bookmark files...")
 
-	var config config.Config
+	var conf config.Config
 	chromeLoader := NewChromeLoader()
-	chromeFinder := NewChromeFinder()
 	clisetting, err := chromeLoader.Load("./settings.json")
 	if err != nil {
-		fmt.Println(err)
-		return model{}
+		var nf *config.NotFoundError
+		var ife *config.InvalidFormatError
+		if errors.As(err, &nf) {
+			fmt.Println("no setting.json file")
+		} else if errors.As(err, &ife) {
+			fmt.Println("invalid format")
+		} else {
+			fmt.Println(err)
+		}
+		panic("failed to initialization")
 	}
-	config.CliSetting = clisetting
-	fmt.Println("Finish loading settings.json")
-	config.SearchPath, err = chromeFinder.Find(config.CliSetting)
 
-	return model{searchString: ti, config: config}
+	conf.CliSetting = clisetting
+	fmt.Println("Finish loading settings.json")
+
+	chromeFinder := NewChromeFinder()
+	conf.SearchPath, err = chromeFinder.Find(conf.CliSetting)
+	if err != nil {
+		var nfb *config.NotFoundBookmarkFileError
+		if errors.As(err, &nfb) {
+			fmt.Println("no bookmark files")
+		} else {
+			fmt.Println(err)
+		}
+		panic("failed to initialization")
+	}
+	return model{searchString: ti, config: conf}
 }
 
 func (m model) Init() tea.Cmd {


### PR DESCRIPTION
## Problem
There is no guideline for error handling, making it difficult to keep the approach consistent.

## Goal
- Add documentation that defines a consistent error handling strategy.

## Implementation
Categorize errors into three patterns based on the complexity of the caller's responsibility.
See commit 200f83f97ab801f5191d78ddef504be004e408c3 for details.

## Result
Clarify and standardize the error handling strategy.