### PR TITLE
Tighten implementation to follow dependency inversion principle

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ type Config struct {
 type SearchPath []string
 
 type CliSetting struct {
-	UserName string `json:"username"`
+	UserName string `json:"USERNAME"`
 	LogLevel string `json:"LOG_LEVEL"`
 }
 

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -1,0 +1,61 @@
+package infra
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/ebisuG/search-all-user-bookmark/internal/config"
+)
+
+type ChromeLoaderImpl struct{}
+type ChromeFinderImpl struct{}
+
+var _ config.Loader = (*ChromeLoaderImpl)(nil)
+var _ config.Finder = (*ChromeFinderImpl)(nil)
+
+func (c *ChromeLoaderImpl) Load(path string) (config.CliSetting, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		//TODO : if debug mode on, display detailed data
+		return config.CliSetting{}, fmt.Errorf("%w", config.NotFoundError{FilePath: path})
+	}
+
+	var cliSetting config.CliSetting
+	if err := json.Unmarshal(data, &cliSetting); err != nil {
+		return config.CliSetting{}, fmt.Errorf("%w", config.ErrInvalidFormat)
+	}
+	return cliSetting, nil
+}
+
+func NewChromeLoader() config.Loader {
+	return &ChromeLoaderImpl{}
+}
+
+func (c *ChromeFinderImpl) Find(cliSetting config.CliSetting) (config.SearchPath, error) {
+	base := "C:\\Users\\" + cliSetting.UserName + "\\AppData\\Local\\Google\\Chrome\\User Data"
+	files, err := os.ReadDir(base)
+	if err != nil {
+		return config.SearchPath{}, errors.New("no such directory : " + base)
+	}
+	var bookmarksFilePath config.SearchPath
+	bookmarksFilePath = append(bookmarksFilePath, base+"\\"+"Default"+"\\Bookmarks")
+	r, _ := regexp.Compile("^Profile [0-9]*")
+
+	for _, v := range files {
+		match := r.MatchString(v.Name())
+		if v.IsDir() && match {
+			bookmarksFilePath = append(bookmarksFilePath, base+"\\"+v.Name()+"\\Bookmarks")
+		}
+	}
+	if len(bookmarksFilePath) == 0 {
+		return config.SearchPath{}, fmt.Errorf("%w", config.NotFoundBookmarkFileError{Path: base})
+	}
+	return bookmarksFilePath, nil
+}
+
+func NewChromeFinder() config.Finder {
+	return &ChromeFinderImpl{}
+}

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -3,55 +3,12 @@ package infra
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
-	"github.com/ebisuG/search-all-user-bookmark/internal/config"
 	"github.com/ebisuG/search-all-user-bookmark/internal/search"
 	"golang.org/x/text/cases"
 )
-
-// This struct is for CLI settings
-type ChromeLoader struct{}
-type ChromeFinder struct{}
-
-func (c ChromeLoader) Load(path string) (config.CliSetting, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		//TODO : if debug mode on, display detailed data
-		return config.CliSetting{}, fmt.Errorf("%w", config.NotFoundError{FilePath: path})
-	}
-
-	var cliSetting config.CliSetting
-	if err := json.Unmarshal(data, &cliSetting); err != nil {
-		return config.CliSetting{}, fmt.Errorf("%w", config.ErrInvalidFormat)
-	}
-	return cliSetting, nil
-}
-
-func (c ChromeFinder) Find(cliSetting config.CliSetting) (config.SearchPath, error) {
-	base := "C:\\Users\\" + cliSetting.UserName + "\\AppData\\Local\\Google\\Chrome\\User Data"
-	files, err := os.ReadDir(base)
-	if err != nil {
-		return config.SearchPath{}, errors.New("no such directory : " + base)
-	}
-	var bookmarksFilePath config.SearchPath
-	bookmarksFilePath = append(bookmarksFilePath, base+"\\"+"Default"+"\\Bookmarks")
-	r, _ := regexp.Compile("^Profile [0-9]*")
-
-	for _, v := range files {
-		match := r.MatchString(v.Name())
-		if v.IsDir() && match {
-			bookmarksFilePath = append(bookmarksFilePath, base+"\\"+v.Name()+"\\Bookmarks")
-		}
-	}
-	if len(bookmarksFilePath) == 0 {
-		return config.SearchPath{}, fmt.Errorf("%w", config.NotFoundBookmarkFileError{Path: base})
-	}
-	return bookmarksFilePath, nil
-}
 
 type ChromeParentJson struct {
 	Checksum     string      `json:"checksum"`

--- a/internal/infra/search.go
+++ b/internal/infra/search.go
@@ -45,6 +45,8 @@ type ChromeMetaInfo struct {
 
 type ChromeParser struct{}
 
+var _ search.Parser = (*ChromeParser)(nil)
+
 func (c ChromeParser) Parse(path string) ([]search.Bookmark, error) {
 	var bookmarks []search.Bookmark
 	data, err := os.ReadFile(path)
@@ -80,7 +82,13 @@ func GetChildren(c ChromeChild) []search.Bookmark {
 	return result
 }
 
+func NewChromeParser() search.Parser {
+	return &ChromeParser{}
+}
+
 type CoreSearcher struct{}
+
+var _ search.Searcher = (*CoreSearcher)(nil)
 
 func (c CoreSearcher) Search(bookmarks search.Bookmarks, keyword string) (search.Bookmarks, error) {
 	var result search.Bookmarks
@@ -94,4 +102,8 @@ func (c CoreSearcher) Search(bookmarks search.Bookmarks, keyword string) (search
 		}
 	}
 	return result, nil
+}
+
+func NewCoreSearcher() search.Searcher {
+	return &CoreSearcher{}
 }

--- a/main.go
+++ b/main.go
@@ -52,20 +52,6 @@ type record struct {
 	norm string
 }
 
-//	func NewChromeLoader() infra.ChromeLoader {
-//		return infra.ChromeLoader{}
-//	}
-//
-//	func NewChromeFinder() infra.ChromeFinder {
-//		return infra.ChromeFinder{}
-//	}
-func NewChromeParser() infra.ChromeParser {
-	return infra.ChromeParser{}
-}
-func NewSearcher() search.Searcher {
-	return infra.CoreSearcher{}
-}
-
 func InitialModel() model {
 	ti := textinput.New()
 	ti.Placeholder = "Search keyword"
@@ -138,7 +124,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				searchWord = append(searchWord, string(v))
 			}
 			var bookmarks search.Bookmarks
-			chromeParser := NewChromeParser()
+			chromeParser := infra.NewChromeParser()
 			for _, v := range m.config.SearchPath {
 				bookmark, err := chromeParser.Parse(v)
 				if err != nil {
@@ -148,7 +134,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				bookmarks = append(bookmarks, bookmark...)
 			}
 
-			searcher := NewSearcher()
+			searcher := infra.NewCoreSearcher()
 			display, err := searcher.Search(bookmarks, strings.Join(searchWord, ""))
 			if err != nil {
 				fmt.Println("failed to search bookmarks")

--- a/main.go
+++ b/main.go
@@ -52,12 +52,13 @@ type record struct {
 	norm string
 }
 
-func NewChromeLoader() infra.ChromeLoader {
-	return infra.ChromeLoader{}
-}
-func NewChromeFinder() infra.ChromeFinder {
-	return infra.ChromeFinder{}
-}
+//	func NewChromeLoader() infra.ChromeLoader {
+//		return infra.ChromeLoader{}
+//	}
+//
+//	func NewChromeFinder() infra.ChromeFinder {
+//		return infra.ChromeFinder{}
+//	}
 func NewChromeParser() infra.ChromeParser {
 	return infra.ChromeParser{}
 }
@@ -77,7 +78,7 @@ func InitialModel() model {
 	fmt.Println("Reading all bookmark files...")
 
 	var conf config.Config
-	chromeLoader := NewChromeLoader()
+	chromeLoader := infra.NewChromeLoader()
 	clisetting, err := chromeLoader.Load("./settings.json")
 	logger := infra.NewLogger(clisetting.LogLevel)
 	logger.Debug("clisetting is:")
@@ -98,7 +99,7 @@ func InitialModel() model {
 	conf.CliSetting = clisetting
 	fmt.Println("Finish loading settings.json")
 
-	chromeFinder := NewChromeFinder()
+	chromeFinder := infra.NewChromeFinder()
 	conf.SearchPath, err = chromeFinder.Find(conf.CliSetting)
 	logger.Debug("conf.SearchPath is:")
 	logger.Debug(conf.SearchPath)

--- a/settings_example.json
+++ b/settings_example.json
@@ -1,3 +1,4 @@
 {
-    "username":"example"
+    "USERNAME":"example",
+    "DEBUG_MODE":"production"
 }


### PR DESCRIPTION
## Problem
Current implementations are not explicitly verified against their intended interfaces.
This weakens adherence to the Dependency Inversion Principle and may reduce testability and long-term maintainability.

## Goal
- Ensure implementations satisfy their interfaces at compile time.
- Make higher-level code depend on interfaces rather than concrete types.

## Implementation
- Split `infra.go` into three files: `config.go`, log.go`, and `search.go` to clarify responsibilities and improve readability.
- Added compile-time interface assertions: 
 ```go
var _ config.Loader = (*ChromeLoaderImpl)(nil)
```
- Exposed constructor functions that return interface types instead of concrete implementations:
```go
func NewChromeLoader() config.Loader {
	return &ChromeLoaderImpl{}
}
```

## Result
- Improved maintainability through explicit compile-time interface verification.
- Reinforced dependency inversion by returning interface types from constructors.
- Improved cohesion by grouping related code into focused files

## Next
Add test cases to validate behavior and further improve reliability.
https://github.com/ebisuG/search-all-user-bookmark/issues/45